### PR TITLE
Fix file handle issues

### DIFF
--- a/src/nuster/cache/engine.c
+++ b/src/nuster/cache/engine.c
@@ -1121,6 +1121,8 @@ void nst_cache_finish(struct nst_cache_ctx *ctx) {
         nst_persist_write_meta(&ctx->disk);
 
         ctx->entry->file = ctx->disk.file;
+        /* here we should close the handle because it is not closed before */
+        close(ctx->disk.fd);
     }
 }
 


### PR DESCRIPTION
Most of the "not closed file handles" are fixed with this update. It is a quick and dirty solution, don't merge to master as is!

This updated code can eliminate 396 not closed file handles from 400. Still there are 4 not closed file handles but have no more time to debug it where they comes (may be later time).

The major problem is that the applet state machine never steps into the APPLET_DONE state where the file handle is closed. The fixed code closes the handle when the last byte is read from the file.

Other place where the code can lose handle is the method 'nst_cache_finish'. In the execution order before that method call somewhere the handle should be closed but it's not happening so I decided to close it there. The proper place should be figured out before it is merged to master.
